### PR TITLE
Test to show problem with logging of stack traces and patch to show f…

### DIFF
--- a/common/dbg/log_panic.go
+++ b/common/dbg/log_panic.go
@@ -29,7 +29,10 @@ import (
 
 // Stack returns stack-trace in logger-friendly compact formatting
 func Stack() string {
-	return stack2.Trace().TrimBelow(stack2.Caller(1)).TrimAbove(stack2.Caller(1)).String()
+	// TODO: The code in main only shows the one line that raised the panic.
+	// We remove the "TrimAbove(stack2.Caller(1))" to show the full stack trace.
+	// return stack2.Trace().TrimBelow(stack2.Caller(1)).TrimAbove(stack2.Caller(1)).String()
+	return stack2.Trace().TrimBelow(stack2.Caller(1)).String()
 }
 func StackSkip(skip int) string {
 	return stack2.Trace().TrimBelow(stack2.Caller(skip)).TrimAbove(stack2.Caller(1)).String()

--- a/rpc/service_test.go
+++ b/rpc/service_test.go
@@ -1,0 +1,43 @@
+// Copyright 2019 The go-ethereum Authors
+// (original work)
+// Copyright 2024 The Erigon Authors
+// (modifications)
+// This file is part of Erigon.
+//
+// Erigon is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Erigon is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Erigon. If not, see <http://www.gnu.org/licenses/>.
+
+package rpc
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/erigontech/erigon/common/log/v3"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCallPanicLogsCorrectly(t *testing.T) {
+	fn := reflect.ValueOf(func() {
+		panic("simulate panic")
+	})
+	logger := log.New("test", "TestCallPanicLogsCorrectly")
+	logBuffer := new(strings.Builder)
+	logger.SetHandler(log.StreamHandler(logBuffer, log.TerminalFormat()))
+	c := &callback{fn: fn, rcvr: reflect.ValueOf(nil), errPos: -1, logger: logger}
+	_, err := c.call(t.Context(), "test", []reflect.Value{}, nil)
+	require.Regexp(t, "method handler crashed", err)
+
+	require.Contains(t, logBuffer.String(), "service_test.go", "Expect to have details about the panic in the log")
+}


### PR DESCRIPTION
Log before:

```
EROR[02-03|16:26:13.094] RPC method test crashed: simulate panic
[service.go:222]
```
Log after:

```
EROR[0m[02-03|16:27:01.373] RPC method test crashed: simulate panic
[service.go:222 panic.go:792 service_test.go:33 value.go:584 value.go:368 service.go:227 service_test.go:39 testing.go:1792 asm_arm64.s:1223]
```